### PR TITLE
Update default commit message

### DIFF
--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -65,7 +65,7 @@ module Bummr
           say outdated_gems_to_update.map { |g| "* #{g}" }.join("\n")
 
           outdated_gems_to_update.each_with_index do |gem, index|
-            message = "#{gem[:name]}, {#{gem[:current_version]} -> #{gem[:spec_version]}}"
+            message = "Update #{gem[:name]} to version #{gem[:spec_version]}"
             say "Updating #{message}, #{index+1} of #{outdated_gems_to_update.count}"
 
             system("bundle update --source #{gem[:name]}")


### PR DESCRIPTION
**Why**: To conform to best practices. A good commit message must be readable as a full sentence and start with an action in the imperative. See the following articles:

http://chris.beams.io/posts/git-commit/
https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
