### PR TITLE
Make bisect work with old git 1.9.1

### DIFF
--- a/lib/bummr/bisecter.rb
+++ b/lib/bummr/bisecter.rb
@@ -6,7 +6,9 @@ module Bummr
       puts "Bad commits found! Bisecting...".red
 
       system("bundle")
-      system("git bisect start head master")
+      system("git bisect start")
+      system("git bisect bad")
+      system("git bisect good master")
 
       Open3.popen2e("git bisect run #{TEST_COMMAND}") do |_std_in, std_out_err|
         while line = std_out_err.gets

--- a/spec/bisecter_spec.rb
+++ b/spec/bisecter_spec.rb
@@ -13,7 +13,7 @@ describe Bummr::Bisecter do
   before do
     allow(STDOUT).to receive(:puts)
     allow(bisecter).to receive(:system).with("bundle")
-    allow(bisecter).to receive(:system).with("git bisect start head master")
+    allow(bisecter).to receive(:system)
   end
 
   describe "#bisect" do


### PR DESCRIPTION
I found that git version 1.9.1 under Debian wheezy does not like
combining the bad & good commands into the bisect start command like so;
git bisect start head master. It starts bisect correctly but it doesn't
set the bad & good points.
