### PR TITLE
FIX invalid log command on update command

### DIFF
--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -1,5 +1,7 @@
 module Bummr
   class Updater
+    include Log
+
     def initialize(outdated_gems)
       @outdated_gems = outdated_gems
     end


### PR DESCRIPTION
When running bummr update it crashes when trying to create a log, I noticed that it was missing the include Log module.
