### PR TITLE
Allow customizing the base branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ The bummr gem allows you to automatically update all gems which pass your
 build in separate commits, and logs the name and sha of each gem that fails.
 
 Bummr assumes you have good test coverage and follow a [pull-request workflow] (https://help.github.com/articles/using-pull-requests/) with `master` as your
-default branch.
+base branch.
+
+The base branch can be overridden by setting the environment variable
+`BUMMR_BASE_BRANCH` to another branch when running commands.
 
 Please note that this gem is *alpha* stage and may have bugs.
 
@@ -37,7 +40,7 @@ Using bummr can take anywhere from a few minutes to several hours, depending
 on the number of outdated gems you have and the number of tests in your test
 suite.
 
-- After installing, create a new, clean branch off of master.
+- After installing, create a new, clean branch off of your base branch.
 - Run `bummr update`. This may take some time.
 - `Bummr` will give you the opportunity to interactively rebase your branch
   before running the tests. Delete any commits for gems which you don't want
@@ -45,7 +48,7 @@ suite.
 - At this point, you can leave `bummr` to work for some time.
 - If your build fails, `bummr` will attempt to automatically remove breaking
   commits, until the build passes, logging any failures to `/log/bummr.log`.
-- Once your build passes, open a pull-request and merge it to your `master` branch.
+- Once your build passes, open a pull-request and merge it to your base branch.
 
 ##### `bummr update`
 
@@ -55,7 +58,7 @@ suite.
 
 `Update gemname from 0.0.1 to 0.0.2`
 
-- Runs `git rebase -i master` to allow you the chance to review and make changes.
+- Runs `git rebase -i your_base_branch` to allow you the chance to review and make changes.
 - Runs `bummr test`
 
 ##### `bummr test`
@@ -65,7 +68,7 @@ suite.
 
 ##### `bummr bisect`
 
-- `git bisect`s against master.
+- `git bisect`s against your base branch.
 - Finds the bad commit and attempts to remove it.
 - Logs the bad commit in `log/bummr.log`.
 - Runs `bummr test`.
@@ -74,7 +77,7 @@ suite.
 
 - Bummr assumes you have good test coverage and follow a [pull-request workflow]
   (https://help.github.com/articles/using-pull-requests/) with `master` as your
-  default branch.
+  base branch.
 - Once the build passes, you can push your branch and create a pull-request!
 - You may wish to `tail -f log/bummr.log` in a separate terminal window so you
   can see which commits are being removed.

--- a/lib/bummr/bisecter.rb
+++ b/lib/bummr/bisecter.rb
@@ -8,7 +8,7 @@ module Bummr
       system("bundle")
       system("git bisect start")
       system("git bisect bad")
-      system("git bisect good master")
+      system("git bisect good #{BASE_BRANCH}")
 
       Open3.popen2e("git bisect run #{TEST_COMMAND}") do |_std_in, std_out_err|
         while line = std_out_err.gets

--- a/lib/bummr/check.rb
+++ b/lib/bummr/check.rb
@@ -5,7 +5,7 @@ module Bummr
     def check(fullcheck=true)
       @errors = []
 
-      check_master
+      check_base_branch
       check_log
       check_status
 
@@ -24,9 +24,10 @@ module Bummr
 
     private
 
-    def check_master
-      if `git rev-parse --abbrev-ref HEAD` == "master\n"
-        message = "Bummr is not meant to be run on master"
+    def check_base_branch
+      if `git rev-parse --abbrev-ref HEAD` == "#{BASE_BRANCH}\n"
+        message = "Bummr is not meant to be run on " \
+          "your base branch #{BASE_BRANCH}"
         puts message.color(:red)
         puts "Please checkout a branch with 'git checkout -b update-gems'"
         @errors.push message
@@ -60,8 +61,8 @@ module Bummr
     end
 
     def check_diff
-      unless `git diff master`.empty?
-        message = "Please make sure that `git diff master` returns empty"
+      unless `git diff #{BASE_BRANCH}`.empty?
+        message = "Please make sure that `git diff #{BASE_BRANCH}` returns empty"
         puts message.color(:red)
         @errors.push message
       end

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -1,4 +1,5 @@
 TEST_COMMAND = ENV["BUMMR_TEST"] || "bundle exec rake"
+BASE_BRANCH = ENV["BUMMR_BASE_BRANCH"] || "master"
 
 module Bummr
   class CLI < Thor
@@ -25,7 +26,7 @@ module Bummr
         else
           Bummr::Updater.new(outdated_gems).update_gems
 
-          system("git rebase -i master")
+          system("git rebase -i #{BASE_BRANCH}")
           test
         end
       else
@@ -59,7 +60,7 @@ module Bummr
 
     def ask_questions
       puts "To run Bummr, you must:"
-      puts "- Be in the root path of a clean git branch off of master"
+      puts "- Be in the root path of a clean git branch off of #{BASE_BRANCH}"
       puts "- Have no commits or local changes"
       puts "- Have a 'log' directory, where we can place logs"
       puts "- Have your build configured to fail fast (recommended)"

--- a/spec/check_spec.rb
+++ b/spec/check_spec.rb
@@ -5,7 +5,7 @@ describe Bummr::Check do
 
   before(:each) do
     allow(check)
-      .to receive(:check_master).and_return(nil)
+      .to receive(:check_base_branch).and_return(nil)
     allow(check)
       .to receive(:check_log).and_return(nil)
     allow(check)
@@ -36,17 +36,17 @@ describe Bummr::Check do
       end
     end
 
-    context "check_master fails" do
+    context "check_base_branch fails" do
       it "reports the error and exits after confirm" do
         allow(check)
-          .to receive(:check_master).and_call_original
+          .to receive(:check_base_branch).and_call_original
         allow(check).to receive(:`).with('git rev-parse --abbrev-ref HEAD')
-          .and_return "master\n"
+          .and_return "#{BASE_BRANCH}\n"
 
         check.check
 
         expect(check).to have_received(:puts)
-          .with("Bummr is not meant to be run on master".color(:red))
+          .with("Bummr is not meant to be run on your base branch #{BASE_BRANCH}".color(:red))
         expect(check).to have_received(:yes?)
         expect(check).to have_received(:exit).with(0)
       end
@@ -106,17 +106,15 @@ describe Bummr::Check do
     end
 
     context "check_diff fails" do
-      before do
-        allow(check).to receive(:check_diff).and_call_original
-        allow(check).to receive(:`).with('git diff master')
-          .and_return "+ file"
-      end
-
       it "reports the error and exits after confirm" do
+        allow(check).to receive(:check_diff).and_call_original
+        allow(check).to receive(:`).with("git diff #{BASE_BRANCH}")
+          .and_return "+ file"
+
         check.check(true)
 
         expect(check).to have_received(:puts)
-          .with("Please make sure that `git diff master` returns empty".color(:red))
+          .with("Please make sure that `git diff #{BASE_BRANCH}` returns empty".color(:red))
         expect(check).to have_received(:yes?)
         expect(check).to have_received(:exit).with(0)
       end

--- a/spec/lib/bisecter_spec.rb
+++ b/spec/lib/bisecter_spec.rb
@@ -12,11 +12,21 @@ describe Bummr::Bisecter do
 
   before do
     allow(STDOUT).to receive(:puts)
-    allow(bisecter).to receive(:system).with("bundle")
     allow(bisecter).to receive(:system)
   end
 
   describe "#bisect" do
+    it "sets up a bisect" do
+      allow(Open3).to receive(:popen2e).and_return(nil)
+
+      bisecter.bisect
+
+      expect(bisecter).to have_received(:system).with("bundle")
+      expect(bisecter).to have_received(:system).with("git bisect start")
+      expect(bisecter).to have_received(:system).with("git bisect bad")
+      expect(bisecter).to have_received(:system).with("git bisect good #{BASE_BRANCH}")
+    end
+
     context "bad commit" do
       it "rebases it out" do
         allow(Open3).to receive(:popen2e).and_yield(nil, std_out_err_bad_commit)

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -54,7 +54,7 @@ describe Bummr::CLI do
           expect(cli).to receive(:log)
           expect(cli).to receive(:system).with("bundle")
           expect(Bummr::Updater).to receive(:new).with(outdated_gems).and_return updater
-          expect(cli).to receive(:system).with("git rebase -i master")
+          expect(cli).to receive(:system).with("git rebase -i #{BASE_BRANCH}")
           expect(cli).to receive(:test)
 
           cli.update


### PR DESCRIPTION
This change allows the user to customize the base branch used for diffing and
rebasing when they use a non-standard primary branch.

It's configurable by setting the `BUMMR_BASE_BRANCH` environment variable.

closes https://github.com/lpender/bummr/issues/34