### PR TITLE
Allow indirect dependencies to be updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ brittle tests and false positives.
 
 By default, bummr will assume your base branch is named `master`. If you would
 like to designate a different base branch, you can set the `BASE_BRANCH`
-environment variable: `export BASE_BRANCH='develop'
+environment variable: `export BASE_BRANCH='develop'`
 
 ## Usage:
 
@@ -60,6 +60,8 @@ instructions in the Installation section of this README.
 - Finds all your outdated gems
 - Updates them each individually, using `bundle update --source #{gemname}`
 - Commits each gem update separately, with a commit message like:
+- Options:
+  - `--all` to include indirect dependencies (`bummr` defaults to direct dependencies only)
 
 `Update gemname from 0.0.1 to 0.0.2`
 

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -11,6 +11,7 @@ module Bummr
     end
 
     desc "update", "Update outdated gems, run tests, bisect if tests fail"
+    method_option :all, type: :boolean, default: false
     def update
       ask_questions
 
@@ -19,7 +20,7 @@ module Bummr
         log("Bummr update initiated #{Time.now}")
         system("bundle")
 
-        outdated_gems = Bummr::Outdated.instance.outdated_gems
+        outdated_gems = Bummr::Outdated.instance.outdated_gems(all_gems: options[:all])
 
         if outdated_gems.empty?
           puts "No outdated gems to update".color(:green)

--- a/lib/bummr/outdated.rb
+++ b/lib/bummr/outdated.rb
@@ -5,23 +5,24 @@ module Bummr
   class Outdated
     include Singleton
 
-    def outdated_gems
-      @outdated_gems ||= begin
-        results = []
+    def outdated_gems(all_gems: false)
+      results = []
 
-        Open3.popen2("bundle outdated --strict") do |_std_in, std_out|
-          while line = std_out.gets
-            puts line
-            gem = parse_gem_from(line)
+      options = []
+      options << "--strict" unless all_gems
 
-            if gem && gemfile_contains(gem[:name])
-              results.push gem
-            end
+      Open3.popen2("bundle outdated", *options) do |_std_in, std_out|
+        while line = std_out.gets
+          puts line
+          gem = parse_gem_from(line)
+
+          if gem && (all_gems || gemfile_contains(gem[:name]))
+            results.push gem
           end
         end
-
-        results
       end
+
+      results
     end
 
     def parse_gem_from(line)

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -60,6 +60,30 @@ describe Bummr::CLI do
           cli.update
         end
       end
+
+      describe "all option" do
+        it "requests all outdated gems be listed" do
+          options[:all] = true
+
+          expect_any_instance_of(Bummr::Outdated)
+            .to receive(:outdated_gems).with({ all_gems: true })
+            .and_return outdated_gems
+
+          updater = double
+          allow(updater).to receive(:update_gems)
+
+          expect(cli).to receive(:ask_questions)
+          expect(cli).to receive(:yes?).and_return(true)
+          expect(cli).to receive(:check)
+          expect(cli).to receive(:log)
+          expect(cli).to receive(:system).with("bundle")
+          expect(Bummr::Updater).to receive(:new).with(outdated_gems).and_return updater
+          expect(cli).to receive(:system).with("git rebase -i #{BASE_BRANCH}")
+          expect(cli).to receive(:test)
+
+          cli.update
+        end
+      end
     end
   end
 

--- a/spec/lib/outdated_spec.rb
+++ b/spec/lib/outdated_spec.rb
@@ -7,6 +7,7 @@ describe Bummr::Outdated do
     output += "  * devise (newest 4.1.1, installed 3.5.2) in group \"default\"\n"
     output += "  * rake (newest 11.1.2, installed 10.4.2)\n"
     output += "  * rails (newest 4.2.6, installed 4.2.5.1, requested ~> 4.2.0) in group \"default\"\n"
+    output += "  * indirect_dep (newest 1.0.0, installed 0.0.1)\n"
     StringIO.new(output)
   }
 
@@ -37,6 +38,30 @@ describe Bummr::Outdated do
       expect(result[2][:name]).to eq('rails')
       expect(result[2][:newest]).to eq('4.2.6')
       expect(result[2][:installed]).to eq('4.2.5.1')
+    end
+
+    describe "all gems option" do
+      it "lists all outdated dependencies by omitting the strict option" do
+        allow(Open3).to receive(:popen2).with("bundle outdated").and_yield(nil, stdoutput)
+
+        allow(Bummr::Outdated.instance).to receive(:gemfile).and_return gemfile
+
+        results = Bummr::Outdated.instance.outdated_gems(all_gems: true)
+        gem_names = results.map { |result| result[:name] }
+
+        expect(gem_names).to include "indirect_dep"
+      end
+
+      it "defaults to false" do
+        expect(Open3).to receive(:popen2).with("bundle outdated", "--strict").and_yield(nil, stdoutput)
+
+        allow(Bummr::Outdated.instance).to receive(:gemfile).and_return gemfile
+
+        results = Bummr::Outdated.instance.outdated_gems
+        gem_names = results.map { |result| result[:name] }
+
+        expect(gem_names).to_not include "indirect_dep"
+      end
     end
   end
 


### PR DESCRIPTION
Thanks for this gem, it's cool!

As referenced in #38, would you consider allowing indirect dependencies (including those in `Gemfile.lock`) to be updated when a flag is specified? Like `bummr update --all`.

I think this feature could be beneficial because it allows easy adoption of bugfixes in indirect dependencies. Otherwise these indirect dependencies may take a while to get updated unless the authors of direct dependencies bump the required versions of their dependencies.