### PR TITLE
Testing approach

### DIFF
--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -20,7 +20,7 @@ module Bummr
         log("Bummr update initiated #{Time.now}")
         system("bundle")
 
-        outdated_gems = Bummr::Outdated.instance.outdated_gems(all_gems: options[:all])
+        outdated_gems = Bummr::Outdated.new.outdated_gems(all_gems: options[:all])
 
         if outdated_gems.empty?
           puts "No outdated gems to update".color(:green)

--- a/lib/bummr/outdated.rb
+++ b/lib/bummr/outdated.rb
@@ -2,8 +2,9 @@ require 'open3'
 
 module Bummr
   class Outdated
-    def initialize(file_reader: File)
+    def initialize(file_reader: File, process_provider: Open3)
       @file_reader = file_reader
+      @process_provider = process_provider
     end
 
     def outdated_gems(all_gems: false)
@@ -12,7 +13,7 @@ module Bummr
       options = []
       options << "--strict" unless all_gems
 
-      Open3.popen2("bundle outdated", *options) do |_std_in, std_out|
+      process_provider.popen2("bundle outdated", *options) do |_std_in, std_out|
         while line = std_out.gets
           puts line
           gem = parse_gem_from(line)
@@ -36,7 +37,7 @@ module Bummr
 
     private
 
-    attr_reader :file_reader
+    attr_reader :file_reader, :process_provider
 
     def gemfile_contains(gem_name)
       /gem ['"]#{gem_name}['"]/.match gemfile

--- a/lib/bummr/outdated.rb
+++ b/lib/bummr/outdated.rb
@@ -1,9 +1,10 @@
 require 'open3'
-require 'singleton'
 
 module Bummr
   class Outdated
-    include Singleton
+    def initialize(file_reader: File)
+      @file_reader = file_reader
+    end
 
     def outdated_gems(all_gems: false)
       results = []
@@ -35,12 +36,14 @@ module Bummr
 
     private
 
+    attr_reader :file_reader
+
     def gemfile_contains(gem_name)
       /gem ['"]#{gem_name}['"]/.match gemfile
     end
 
     def gemfile
-      @gemfile ||= `cat Gemfile`
+      @gemfile ||= file_reader.read("Gemfile")
     end
   end
 end

--- a/spec/lib/outdated_spec.rb
+++ b/spec/lib/outdated_spec.rb
@@ -20,8 +20,14 @@ describe Bummr::Outdated do
   }
 
   let(:file_reader) { class_double(File) }
+  let(:process_provider) { class_double(Open3) }
 
-  subject { described_class.new(file_reader: file_reader) }
+  subject do
+    described_class.new(
+      file_reader: file_reader,
+      process_provider: process_provider,
+    )
+  end
 
   describe "#outdated_gems" do
     before(:each) do
@@ -29,7 +35,7 @@ describe Bummr::Outdated do
     end
 
     it "Correctly identifies outdated gems" do
-      allow(Open3).to receive(:popen2).and_yield(nil, stdoutput)
+      allow(process_provider).to receive(:popen2).and_yield(nil, stdoutput)
 
       result = subject.outdated_gems
 
@@ -48,7 +54,7 @@ describe Bummr::Outdated do
 
     describe "all gems option" do
       it "lists all outdated dependencies by omitting the strict option" do
-        allow(Open3).to receive(:popen2).with("bundle outdated").and_yield(nil, stdoutput)
+        expect(process_provider).to receive(:popen2).with("bundle outdated").and_yield(nil, stdoutput)
 
         results = subject.outdated_gems(all_gems: true)
         gem_names = results.map { |result| result[:name] }
@@ -57,7 +63,7 @@ describe Bummr::Outdated do
       end
 
       it "defaults to false" do
-        expect(Open3).to receive(:popen2).with("bundle outdated", "--strict").and_yield(nil, stdoutput)
+        expect(process_provider).to receive(:popen2).with("bundle outdated", "--strict").and_yield(nil, stdoutput)
 
         results = subject.outdated_gems
         gem_names = results.map { |result| result[:name] }


### PR DESCRIPTION
Whilst making a contribution yesterday I noticed a couple of areas of the test suite that could potentially be improved.

In particular there's quite a bit of stubbing private methods, including the subject under test, which is often considered an antipattern ([reference from Sam Phippen's blog](https://samphippen.com/introducing-rspec-smells/#smell1stubject) - an RSpec core member). Here's one instance of this:

```ruby
allow_any_instance_of(described_class).to receive(:gemfile).and_return gemfile
```

Additionally, by making many of the core `Bummr` classes Singletons this forces the use of `#allow_any_instance_of` which is listed under RSpec's '[testing legacy code](https://relishapp.com/rspec/rspec-mocks/v/3-6/docs/working-with-legacy-code)' section and isn't recommended.

Would you be open to PRs to inject dependencies and alter these tests so stubbing the subject under test & global constants can be avoided?

No problem if this isn't of interest - I just wanted to see if I can help improve this handy tool.

---

The code below is a quick illustration of how this rewrite would look for the `Bummr::Outdated` class.