### PR TITLE
Add 'group' argument to 'bummr update'

### DIFF
--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -12,6 +12,7 @@ module Bummr
 
     desc "update", "Update outdated gems, run tests, bisect if tests fail"
     method_option :all, type: :boolean, default: false
+    method_option :group, type: :string
     def update
       ask_questions
 
@@ -20,7 +21,9 @@ module Bummr
         log("Bummr update initiated #{Time.now}")
         system("bundle")
 
-        outdated_gems = Bummr::Outdated.instance.outdated_gems(all_gems: options[:all])
+        outdated_gems = Bummr::Outdated.instance.outdated_gems(
+          all_gems: options[:all], group: options[:group]
+        )
 
         if outdated_gems.empty?
           puts "No outdated gems to update".color(:green)

--- a/lib/bummr/outdated.rb
+++ b/lib/bummr/outdated.rb
@@ -5,18 +5,19 @@ module Bummr
   class Outdated
     include Singleton
 
-    def outdated_gems(all_gems: false)
+    def outdated_gems(options = {})
       results = []
 
-      options =  ""
-      options << " --strict" unless all_gems
+      bundle_options =  ""
+      bundle_options << " --strict" unless options[:all_gems]
+      bundle_options << " --group #{options[:group]}" if options[:group]
 
-      Open3.popen2("bundle outdated" + options) do |_std_in, std_out|
+      Open3.popen2("bundle outdated" + bundle_options) do |_std_in, std_out|
         while line = std_out.gets
           puts line
           gem = parse_gem_from(line)
 
-          if gem && (all_gems || gemfile_contains(gem[:name]))
+          if gem && (options[:all_gems] || gemfile_contains(gem[:name]))
             results.push gem
           end
         end

--- a/lib/bummr/version.rb
+++ b/lib/bummr/version.rb
@@ -1,3 +1,3 @@
 module Bummr
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -66,7 +66,7 @@ describe Bummr::CLI do
           options[:all] = true
 
           expect_any_instance_of(Bummr::Outdated)
-            .to receive(:outdated_gems).with({ all_gems: true })
+            .to receive(:outdated_gems).with(hash_including({ all_gems: true }))
             .and_return outdated_gems
 
           updater = double

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -79,6 +79,20 @@ describe Bummr::CLI do
           cli.update
         end
       end
+
+      describe "group option" do
+        it "requests only outdated gems from supplied be listed" do
+          options[:group] = 'test'
+
+          expect_any_instance_of(Bummr::Outdated)
+            .to receive(:outdated_gems).with(hash_including({ group: 'test' }))
+            .and_return outdated_gems
+
+          mock_bummr_standard_flow
+
+          cli.update
+        end
+      end
     end
   end
 

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -25,6 +25,20 @@ describe Bummr::CLI do
     end
 
     context "when user agrees to move forward" do
+      def mock_bummr_standard_flow
+        updater = double
+        allow(updater).to receive(:update_gems)
+
+        expect(cli).to receive(:ask_questions)
+        expect(cli).to receive(:yes?).and_return(true)
+        expect(cli).to receive(:check)
+        expect(cli).to receive(:log)
+        expect(cli).to receive(:system).with("bundle")
+        expect(Bummr::Updater).to receive(:new).with(outdated_gems).and_return updater
+        expect(cli).to receive(:system).with("git rebase -i #{BASE_BRANCH}")
+        expect(cli).to receive(:test)
+      end
+
       context "and there are no outdated gems" do
         it "informs that there are no outdated gems" do
           allow_any_instance_of(Bummr::Outdated).to receive(:outdated_gems)
@@ -45,17 +59,8 @@ describe Bummr::CLI do
         it "calls 'update' on the updater" do
           allow_any_instance_of(Bummr::Outdated).to receive(:outdated_gems)
             .and_return outdated_gems
-          updater = double
-          allow(updater).to receive(:update_gems)
 
-          expect(cli).to receive(:ask_questions)
-          expect(cli).to receive(:yes?).and_return(true)
-          expect(cli).to receive(:check)
-          expect(cli).to receive(:log)
-          expect(cli).to receive(:system).with("bundle")
-          expect(Bummr::Updater).to receive(:new).with(outdated_gems).and_return updater
-          expect(cli).to receive(:system).with("git rebase -i #{BASE_BRANCH}")
-          expect(cli).to receive(:test)
+          mock_bummr_standard_flow
 
           cli.update
         end
@@ -69,17 +74,7 @@ describe Bummr::CLI do
             .to receive(:outdated_gems).with(hash_including({ all_gems: true }))
             .and_return outdated_gems
 
-          updater = double
-          allow(updater).to receive(:update_gems)
-
-          expect(cli).to receive(:ask_questions)
-          expect(cli).to receive(:yes?).and_return(true)
-          expect(cli).to receive(:check)
-          expect(cli).to receive(:log)
-          expect(cli).to receive(:system).with("bundle")
-          expect(Bummr::Updater).to receive(:new).with(outdated_gems).and_return updater
-          expect(cli).to receive(:system).with("git rebase -i #{BASE_BRANCH}")
-          expect(cli).to receive(:test)
+          mock_bummr_standard_flow
 
           cli.update
         end


### PR DESCRIPTION
## Motivation
Updating production gems is a process that should be treated more rigorously than updating 'development' or 'test' gems, and only trusting your automated tests suite can prove fatally  dangerous, so this PR adds the possibility to only update gems from the supplied 'group' argument

## Decisions
- Converted the argument for `Outdated#outdated_gems` to a options hash, so I could add a new option without breaking changes
- DRY'ed up `CLI` specs, isolating setup steps that were being repeated in several tests
- Purposely did not comply to some of rubocop's warnings to maintain the file's current style

## Usage Example
```bash
bummr update --group development
```
(will only update gems from the `development` group) 