### PR TITLE
Prevent Thor warning on boot

### DIFF
--- a/lib/bummr/check.rb
+++ b/lib/bummr/check.rb
@@ -2,6 +2,7 @@ module Bummr
   class Check < Thor
     include Singleton
 
+    desc "check", "Run automated checks to see if bummr can be run"
     def check(fullcheck=true)
       @errors = []
 


### PR DESCRIPTION
Add desc to check command to avoid warning on boot.

[WARNING] Attempted to create command "check" without usage or description. Call desc if you want this method to be available as command or declare it inside a no_commands{} block. Invoked from