### PR TITLE
Headless mode

### DIFF
--- a/lib/bummr.rb
+++ b/lib/bummr.rb
@@ -1,5 +1,6 @@
 # grouped by dependency order than alpha
 require 'bummr/log'
+require 'bummr/prompt'
 require 'rainbow/ext/string'
 require 'open3'
 require 'singleton'

--- a/lib/bummr/check.rb
+++ b/lib/bummr/check.rb
@@ -1,6 +1,7 @@
 module Bummr
   class Check < Thor
     include Singleton
+    include Bummr::Prompt
 
     desc "check", "Run automated checks to see if bummr can be run"
     def check(fullcheck=true)

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -1,9 +1,11 @@
 TEST_COMMAND = ENV["BUMMR_TEST"] || "bundle exec rake"
 BASE_BRANCH = ENV["BASE_BRANCH"] || "master"
+HEADLESS = ENV["BUMMR_HEADLESS"] || false
 
 module Bummr
   class CLI < Thor
     include Bummr::Log
+    include Bummr::Prompt
 
     desc "check", "Run automated checks to see if bummr can be run"
     def check(fullcheck=true)

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -15,7 +15,7 @@ module Bummr
     method_option :group, type: :string
     def update
       system("bundle install")
-      ask_questions
+      display_info
 
       if yes? "Are you ready to use Bummr? (y/n)"
         check
@@ -72,7 +72,7 @@ module Bummr
 
     private
 
-    def ask_questions
+    def display_info
       puts "Bummr #{VERSION}"
       puts "To run Bummr, you must:"
       puts "- Be in the root path of a clean git branch off of #{BASE_BRANCH}"

--- a/lib/bummr/prompt.rb
+++ b/lib/bummr/prompt.rb
@@ -1,0 +1,14 @@
+module Bummr
+  module Prompt
+    def yes?(*args)
+      headless? || super
+    end
+
+    private
+
+    def headless?
+      HEADLESS == true ||
+        HEADLESS == "true"
+    end
+  end
+end

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -94,6 +94,24 @@ describe Bummr::CLI do
         end
       end
     end
+
+    context "when in headless mode" do
+      context "and there are no outdated gems" do
+        it "informs that there are no outdated gems" do
+          stub_const("HEADLESS", true)
+          allow_any_instance_of(Bummr::Outdated).to receive(:outdated_gems)
+            .and_return []
+
+          expect(cli).to receive(:display_info)
+          expect(cli).to receive(:check)
+          expect(cli).to receive(:log)
+          expect(cli).to receive(:system).with("bundle install")
+          expect(cli).to receive(:puts).with("No outdated gems to update".color(:green))
+
+          cli.update
+        end
+      end
+    end
   end
 
   describe "#test" do

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -29,7 +29,7 @@ describe Bummr::CLI do
         updater = double
         allow(updater).to receive(:update_gems)
 
-        expect(cli).to receive(:ask_questions)
+        expect(cli).to receive(:display_info)
         expect(cli).to receive(:yes?).and_return(true)
         expect(cli).to receive(:check)
         expect(cli).to receive(:log)
@@ -44,7 +44,7 @@ describe Bummr::CLI do
           allow_any_instance_of(Bummr::Outdated).to receive(:outdated_gems)
             .and_return []
 
-          expect(cli).to receive(:ask_questions)
+          expect(cli).to receive(:display_info)
           expect(cli).to receive(:yes?).and_return(true)
           expect(cli).to receive(:check)
           expect(cli).to receive(:log)

--- a/spec/lib/prompt_spec.rb
+++ b/spec/lib/prompt_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+describe Bummr::Prompt do
+  let(:parent_class) do
+    Class.new do
+      def yes?(message)
+        "called parent with #{message}"
+      end
+    end
+  end
+  let(:object_class) { Class.new(parent_class) }
+  let(:object) { object_class.new }
+
+  before do
+    object.extend(Bummr::Prompt)
+  end
+
+  describe "#yes?" do
+    context "when HEADLESS is false" do
+      it "calls super" do
+        stub_const("HEADLESS", false)
+
+        expect(
+          object.yes?("foo")
+        ).to eq "called parent with foo"
+      end
+    end
+
+    context "when HEADLESS is nil" do
+      it "calls super" do
+        stub_const("HEADLESS", nil)
+
+        expect(
+          object.yes?("foo")
+        ).to eq "called parent with foo"
+      end
+    end
+
+    context "when HEADLESS is true" do
+      it "returns true and skips asking for user input" do
+        stub_const("HEADLESS", true)
+
+        expect(
+          object.yes?("foo")
+        ).to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the start of an idea for headless mode. I am curious if a complete example would get merged?

My goal is to be able to run this automatically on CI and have the job commit all successful updates.
Currently this is not possible due to the interactive nature of the cli.

This requires a few more changes (ie `git rebase -i`), but is pretty close to all that is needed.