### PR TITLE
Black box test

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,6 @@ wish to use it with.
 
 `rake` will run the suite of unit tests.
 
-I'd like to create feature tests, but because Bummr relies on command line
-manipulations which need to be doubled, I'm waiting on [this
-issue](https://github.com/bjoernalbers/aruba-doubles/issues/5)
-
 ## Thank you!
 
 Thanks to Ryan Sonnek for the [Bundler

--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ build in separate commits, and logs the name and sha of each gem that fails.
 Bummr assumes you have good test coverage and follow a [pull-request workflow]
 with `master` as your default branch.
 
-Please note that this gem is *alpha* stage and may have bugs.
+Please note that this gem is _alpha_ stage and may have bugs.
 
 ## Installation
 
 ```bash
 $ gem install bummr
 ```
+
+To run headless (skip interactive rebasing/confirmation), use
+`BUMMR_HEADLESS=true bundle exec bummr update`.
 
 By default, bummr will use `bundle exec rake` to run your build.
 
@@ -52,8 +55,8 @@ instructions in the Installation section of this README.
   before running the tests. Careful.
 - At this point, you can leave `bummr` to work for some time.
 - If your build fails, `bummr` will notify you of failures, logging the failures to
-  `log/bummr.log`. At this point it is recommended that you lock that gem version in 
-  your Gemfile and start the process over from the top. Alternatively, you may wish 
+  `log/bummr.log`. At this point it is recommended that you lock that gem version in
+  your Gemfile and start the process over from the top. Alternatively, you may wish
   to implement code changes which fix the problem.
 - Once your build passes, open a pull-request and merge it to your `master` branch.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ wish to use it with.
 
 `rake` will run the suite of unit tests.
 
+The suite relies on Oliver Peate's [jet
+black](https://github.com/odlp/jet_black) testing library for command line feature
+tests.
+
 ## Thank you!
 
 Thanks to Ryan Sonnek for the [Bundler

--- a/bummr.gemspec
+++ b/bummr.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "guard"
+  spec.add_development_dependency "jet_black", "~> 0.3"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-remote"
   spec.add_development_dependency "pry-nav"

--- a/lib/bummr/git.rb
+++ b/lib/bummr/git.rb
@@ -17,7 +17,7 @@ module Bummr
     end
 
     def rebase_interactive(sha)
-      system("git rebase -i #{BASE_BRANCH}")
+      system("git rebase -i #{BASE_BRANCH}") unless HEADLESS
     end
 
     def message(sha)

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -36,7 +36,9 @@ module Bummr
         log("#{gem[:name]} not updated from #{gem[:installed]} to latest: #{gem[:newest]}")
       end
 
-      git.add("Gemfile Gemfile.lock vendor/cache")
+      git.add("Gemfile")
+      git.add("Gemfile.lock")
+      git.add("vendor/cache")
       git.commit(message)
     end
 

--- a/spec/black_box/bummr_update_spec.rb
+++ b/spec/black_box/bummr_update_spec.rb
@@ -40,7 +40,7 @@ describe "bummr update command" do
     update_result = session.run(
       "bundle exec bummr update",
       stdin: "y\ny\ny\n",
-      env: { EDITOR: nil },
+      env: { EDITOR: nil, BUMMR_HEADLESS: "true" },
     )
 
     rake_gem_updated = /Update rake from 10\.\d\.\d to 1[1-9]\.\d\.\d/

--- a/spec/black_box/bummr_update_spec.rb
+++ b/spec/black_box/bummr_update_spec.rb
@@ -13,14 +13,12 @@ describe "bummr update command" do
     RUBY
 
     session.create_file "Rakefile", <<~RUBY
-      task :say_hi do
+      task :default do
         puts "Hello from the Rakefile"
       end
-
-      task default: :say_hi
     RUBY
 
-    expect(session.run("bundle install")).
+    expect(session.run("bundle install --retry 3")).
       to be_a_success.and have_stdout(/bummr .* from source/)
 
     # Now allow newer versions of Rake to be installed
@@ -50,8 +48,5 @@ describe "bummr update command" do
 
     expect(session.run("bundle show")).
       to be_a_success.and have_stdout(/rake\s\(1[1-9]/)
-
-    expect(session.run("bundle exec rake")).
-      to be_a_success.and have_stdout("Hello from the Rakefile")
   end
 end

--- a/spec/black_box/bummr_update_spec.rb
+++ b/spec/black_box/bummr_update_spec.rb
@@ -25,9 +25,16 @@ describe "bummr update command" do
     session.run("sed -i.bak 's/, \"~> 10.0\"//' Gemfile")
 
     session.run("mkdir -p log")
-    session.run("git init .")
-    session.run("git add .")
-    session.run("git commit -m 'Initial commit'")
+
+    expect(session.run("git init .")).
+      to be_a_success.and have_stdout("Initialized empty Git repository")
+
+    session.run("git config user.name 'Bummr Test'")
+    session.run("git config user.email 'test@example.com'")
+
+    expect(session.run("git add . && git commit -m 'Initial commit'")).
+      to be_a_success.and have_stdout("Initial commit")
+
     session.run("git checkout -b bummr-branch")
 
     update_result = session.run(

--- a/spec/black_box/bummr_update_spec.rb
+++ b/spec/black_box/bummr_update_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+require "jet_black"
+
+describe "bummr update command" do
+  let(:session) { JetBlack::Session.new(options: { clean_bundler_env: true }) }
+  let(:bummr_gem_path) { File.expand_path("../../", __dir__) }
+
+  it "updates outdated gems" do
+    session.create_file "Gemfile", <<~RUBY
+      source "https://rubygems.org"
+      gem "rake", "~> 10.0"
+      gem "bummr", path: "#{bummr_gem_path}"
+    RUBY
+
+    session.create_file "Rakefile", <<~RUBY
+      task :say_hi do
+        puts "Hello from the Rakefile"
+      end
+
+      task default: :say_hi
+    RUBY
+
+    expect(session.run("bundle install")).
+      to be_a_success.and have_stdout(/bummr .* from source/)
+
+    # Now allow newer versions of Rake to be installed
+    session.run("sed -i.bak 's/, \"~> 10.0\"//' Gemfile")
+
+    session.run("mkdir -p log")
+    session.run("git init .")
+    session.run("git add .")
+    session.run("git commit -m 'Initial commit'")
+    session.run("git checkout -b bummr-branch")
+
+    update_result = session.run(
+      "bundle exec bummr update",
+      stdin: "y\ny\ny\n",
+      env: { EDITOR: nil },
+    )
+
+    rake_gem_updated = /Update rake from 10\.\d\.\d to 1[1-9]\.\d\.\d/
+
+    expect(update_result).
+      to be_a_success.and have_stdout(rake_gem_updated)
+
+    expect(update_result).to have_stdout("Passed the build!")
+
+    expect(session.run("git log")).
+      to be_a_success.and have_stdout(rake_gem_updated)
+
+    expect(session.run("bundle show")).
+      to be_a_success.and have_stdout(/rake\s\(1[1-9]/)
+
+    expect(session.run("bundle exec rake")).
+      to be_a_success.and have_stdout("Hello from the Rakefile")
+  end
+end

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -91,7 +91,9 @@ describe Bummr::Updater do
 
         updater.update_gem(gem, 0)
 
-        expect(git).to have_received(:add).with("Gemfile Gemfile.lock vendor/cache")
+        expect(git).to have_received(:add).with("Gemfile")
+        expect(git).to have_received(:add).with("Gemfile.lock")
+        expect(git).to have_received(:add).with("vendor/cache")
         expect(git).to have_received(:commit).with(commit_message)
       end
     end
@@ -111,7 +113,9 @@ describe Bummr::Updater do
 
         updater.update_gem(gem, 0)
 
-        expect(git).to have_received(:add).with("Gemfile Gemfile.lock vendor/cache")
+        expect(git).to have_received(:add).with("Gemfile")
+        expect(git).to have_received(:add).with("Gemfile.lock")
+        expect(git).to have_received(:add).with("vendor/cache")
         expect(git).to have_received(:commit).with(commit_message)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,4 @@ SimpleCov.start
 require 'pry'
 require 'bummr'
 require 'rainbow/ext/string'
+require 'jet_black/rspec'


### PR DESCRIPTION
To prevent regressions, such as #44, it'd be useful to have higher-level tests which invoke `bummr` in a separate process, with no stubbing.

This first test exercises `bummr update`. Overview of the steps:

- Creates a new Gemfile with Rake `0.10.0` (outdated)
- Commits and create a new branch
- Runs `bummr update`
- Checks `bummr` updated this temporary project to a new version of Rake