### PR TITLE
Supports Bundler 2.2

### DIFF
--- a/lib/bummr/outdated.rb
+++ b/lib/bummr/outdated.rb
@@ -1,5 +1,6 @@
 require 'open3'
 require 'singleton'
+require 'bundler'
 
 module Bummr
   class Outdated

--- a/lib/bummr/outdated.rb
+++ b/lib/bummr/outdated.rb
@@ -9,6 +9,7 @@ module Bummr
       results = []
 
       bundle_options =  ""
+      bundle_options << " --parseable" if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new("2")
       bundle_options << " --strict" unless options[:all_gems]
       bundle_options << " --group #{options[:group]}" if options[:group]
       bundle_options << " #{options[:gem]}" if options[:gem]
@@ -28,7 +29,7 @@ module Bummr
     end
 
     def parse_gem_from(line)
-      regex = / \* (.*) \(newest (\d[\d\.]*\d)[,\s] installed (\d[\d\.]*\d)[\),\s]/.match line
+      regex = /(?:\s+\* )?(.*) \(newest (\d[\d\.]*\d)[,\s] installed (\d[\d\.]*\d)[\),\s]/.match line
 
       unless regex.nil?
         { name: regex[1], newest: regex[2], installed: regex[3] }

--- a/spec/lib/outdated_spec.rb
+++ b/spec/lib/outdated_spec.rb
@@ -2,13 +2,18 @@ require 'spec_helper'
 
 describe Bummr::Outdated do
   # https://github.com/wireframe/gitx/blob/8e3cdc8b5d0c2082ed3daaf2fc054654b2e7a6c8/spec/gitx/executor_spec.rb#L9
-  let(:stdoutput) {
+  let(:stdoutput_legacy) {
     output = String.new
     output += "  * devise (newest 4.1.1, installed 3.5.2) in group \"default\"\n"
     output += "  * rake (newest 11.1.2, installed 10.4.2)\n"
     output += "  * rails (newest 4.2.6, installed 4.2.5.1, requested ~> 4.2.0) in group \"default\"\n"
     output += "  * spring (newest 4.2.6, installed 4.2.5.1, requested ~> 4.2.0) in group \"development\"\n"
     output += "  * indirect_dep (newest 1.0.0, installed 0.0.1)\n"
+    StringIO.new(output)
+  }
+
+  let(:stdoutput) {
+    output = stdoutput_legacy.string.gsub(/^([\s*]+)/, "")
     StringIO.new(output)
   }
 
@@ -22,33 +27,35 @@ describe Bummr::Outdated do
   }
 
   describe "#outdated_gems" do
-    it "Correctly identifies outdated gems" do
-      allow(Open3).to receive(:popen2).and_yield(nil, stdoutput)
-      allow_any_instance_of(described_class).to receive(:gemfile).and_return gemfile
+    { bundler2: :stdoutput, bundler1: :stdoutput_legacy }.each_pair do |version, output|
+    it "Correctly identifies outdated gems with bundler #{version}" do
+      allow(Open3).to receive(:popen2).and_yield(nil, public_send(output))
+        allow_any_instance_of(described_class).to receive(:gemfile).and_return gemfile
 
-      instance = Bummr::Outdated.instance
-      result = instance.outdated_gems
+        instance = Bummr::Outdated.instance
+        result = instance.outdated_gems
 
-      expect(result[0][:name]).to eq('devise')
-      expect(result[0][:newest]).to eq('4.1.1')
-      expect(result[0][:installed]).to eq('3.5.2')
+        expect(result[0][:name]).to eq('devise')
+        expect(result[0][:newest]).to eq('4.1.1')
+        expect(result[0][:installed]).to eq('3.5.2')
 
-      expect(result[1][:name]).to eq('rake')
-      expect(result[1][:newest]).to eq('11.1.2')
-      expect(result[1][:installed]).to eq('10.4.2')
+        expect(result[1][:name]).to eq('rake')
+        expect(result[1][:newest]).to eq('11.1.2')
+        expect(result[1][:installed]).to eq('10.4.2')
 
-      expect(result[2][:name]).to eq('rails')
-      expect(result[2][:newest]).to eq('4.2.6')
-      expect(result[2][:installed]).to eq('4.2.5.1')
+        expect(result[2][:name]).to eq('rails')
+        expect(result[2][:newest]).to eq('4.2.6')
+        expect(result[2][:installed]).to eq('4.2.5.1')
 
-      expect(result[3][:name]).to eq('spring')
-      expect(result[3][:newest]).to eq('4.2.6')
-      expect(result[3][:installed]).to eq('4.2.5.1')
+        expect(result[3][:name]).to eq('spring')
+        expect(result[3][:newest]).to eq('4.2.6')
+        expect(result[3][:installed]).to eq('4.2.5.1')
+      end
     end
 
     describe "all gems option" do
       it "lists all outdated dependencies by omitting the strict option" do
-        allow(Open3).to receive(:popen2).with("bundle outdated").and_yield(nil, stdoutput)
+        allow(Open3).to receive(:popen2).with("bundle outdated --parseable").and_yield(nil, stdoutput)
 
         allow(Bummr::Outdated.instance).to receive(:gemfile).and_return gemfile
 
@@ -59,7 +66,7 @@ describe Bummr::Outdated do
       end
 
       it "defaults to false" do
-        expect(Open3).to receive(:popen2).with("bundle outdated --strict").and_yield(nil, stdoutput)
+        expect(Open3).to receive(:popen2).with("bundle outdated --parseable --strict").and_yield(nil, stdoutput)
 
         allow(Bummr::Outdated.instance).to receive(:gemfile).and_return gemfile
 
@@ -73,13 +80,13 @@ describe Bummr::Outdated do
     describe "group option" do
       let(:stdoutput_from_development_group) {
         output = String.new
-        output += "  * spring (newest 4.2.6, installed 4.2.5.1, requested ~> 4.2.0)"
+        output += "spring (newest 4.2.6, installed 4.2.5.1, requested ~> 4.2.0)"
         StringIO.new(output)
       }
 
       it "lists outdated gems only from supplied group" do
         allow(Open3).to receive(:popen2)
-          .with("bundle outdated --strict --group development")
+          .with("bundle outdated --parseable --strict --group development")
           .and_yield(nil, stdoutput_from_development_group)
 
         allow(Bummr::Outdated.instance).to receive(:gemfile).and_return gemfile
@@ -92,7 +99,7 @@ describe Bummr::Outdated do
 
       it "defaults to all groups" do
         allow(Open3).to receive(:popen2)
-          .with("bundle outdated --strict")
+          .with("bundle outdated --parseable --strict")
           .and_yield(nil, stdoutput)
 
         allow(Bummr::Outdated.instance).to receive(:gemfile).and_return gemfile
@@ -107,13 +114,13 @@ describe Bummr::Outdated do
     describe "gem option" do
       let(:stdoutput_from_spring_gem) {
         output = String.new
-        output += "  * spring (newest 4.2.6, installed 4.2.5.1, requested ~> 4.2.0)"
+        output += "spring (newest 4.2.6, installed 4.2.5.1, requested ~> 4.2.0)"
         StringIO.new(output)
       }
 
       it "lists outdated gems only from supplied gem" do
         allow(Open3).to receive(:popen2)
-          .with("bundle outdated --strict spring")
+          .with("bundle outdated --parseable --strict spring")
           .and_yield(nil, stdoutput_from_spring_gem)
 
         allow(Bummr::Outdated.instance).to receive(:gemfile).and_return gemfile
@@ -128,7 +135,7 @@ describe Bummr::Outdated do
 
   describe "#parse_gem_from" do
     it 'line' do
-      line = '  * devise (newest 4.1.1, installed 3.5.2) in group "default"'
+      line = 'devise (newest 4.1.1, installed 3.5.2) in group "default"'
 
       gem = Bummr::Outdated.instance.parse_gem_from(line)
 
@@ -138,7 +145,7 @@ describe Bummr::Outdated do
     end
 
     it 'line in group' do
-      line = '  * rake (newest 11.1.2, installed 10.4.2)'
+      line = 'rake (newest 11.1.2, installed 10.4.2)'
 
       gem = Bummr::Outdated.instance.parse_gem_from(line)
 
@@ -148,7 +155,7 @@ describe Bummr::Outdated do
     end
 
     it 'line with requested' do
-      line = '  * rails (newest 4.2.6, installed 4.2.5.1, requested ~> 4.2.0) in group "default"'
+      line = 'rails (newest 4.2.6, installed 4.2.5.1, requested ~> 4.2.0) in group "default"'
 
       gem = Bummr::Outdated.instance.parse_gem_from(line)
 


### PR DESCRIPTION
We can use the `--parseable` option, available since at least Bundler v2.0, to get back almost the same output than Bundler v1 (minus the asterisks at the beginning).