### PR TITLE
Handle similar gem names in updated_version_for

### DIFF
--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -44,7 +44,7 @@ module Bummr
 
     def updated_version_for(gem)
       string = `bundle list --paths | grep "#{gem[:name]}"`
-      string.match(/#{gem[:name]}-(.*)$/)[1]
+      string.match(/#{File::SEPARATOR}#{gem[:name]}-(.*)$/)[1]
     end
   end
 end

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -129,5 +129,16 @@ describe Bummr::Updater do
 
       expect(updater.updated_version_for(gem)).to eq "3.5.2"
     end
+
+    it "returns the correct version when there are similarly named gems" do
+      allow(updater).to receive(:`).with(
+        "bundle list --paths | grep \"#{gem[:name]}\""
+      ).and_return(<<~BUNDLE_LIST)
+        asdf/asdf/asdf/foo-#{gem[:name]}-1.2.3
+        asdf/asdf/asdf/#{gem[:name]}-3.5.2
+      BUNDLE_LIST
+
+      expect(updater.updated_version_for(gem)).to eq "3.5.2"
+    end
   end
 end


### PR DESCRIPTION
Bummr can get confused when updating a gem when there is another gem used by the project that is named similarly but with a prefix. E.g. when updating websockets, bummr can get confused by the presence of em-websockets and pick the version number of em-websockets for the commit message.

This commit fixes that problem by anchoring the regex on the directory separator.

Note that I'm not sure how this behaves on Windows. My hope is that `bundle list --paths` uses the directory separator as is specified in `File::SEPARATOR`, but this is untested.