### PR TITLE
Launch git bisect within top level folder.

### DIFF
--- a/lib/bummr/bisecter.rb
+++ b/lib/bummr/bisecter.rb
@@ -5,12 +5,14 @@ module Bummr
     def bisect
       puts "Bad commits found! Bisecting...".color(:red)
 
-      system("bundle")
-      system("git bisect start")
-      system("git bisect bad")
-      system("git bisect good #{BASE_BRANCH}")
+      toplevel_path = `git rev-parse --show-toplevel`.chomp
 
-      Open3.popen2e("git bisect run #{TEST_COMMAND}") do |_std_in, std_out_err|
+      system("bundle")
+      system("git -C #{toplevel_path} bisect start")
+      system("git -C #{toplevel_path} bisect bad")
+      system("git -C #{toplevel_path} bisect good #{BASE_BRANCH}")
+
+      Open3.popen2e("git -C #{toplevel_path} bisect run #{TEST_COMMAND}") do |_std_in, std_out_err|
         while line = std_out_err.gets
           puts line
 


### PR DESCRIPTION
Hi,

First of all thanks for sharing this gem :+1: 

We encountered an issue while working within a monorepos. Let's imagine the tree of the project is :
```
root
|_ api # rails app
|_ gui # any frontend app
|_ doc
```

When we use `bummr` within the **api** folder the updates of gems and the launch of the test suite works, but if the tests fail we have the log `You need to run this command from the toplevel of the working tree.` four times and it stops. The culprit is `git-bisect` which has to be launched at the root of the project :thinking: 

Here is a PR to fix this _issue_.

Note : it needs to provide a TEST_COMMAND with an absolute path in order that `bummer update` and `bummer bisect` run well.

Hope it helps.