### PR TITLE
Cleanup spec tests and gem build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.yardoc
 /_yardoc/
 /coverage/
+/log/
 /doc/
 /pkg/
 /spec/reports/
@@ -10,4 +11,6 @@
 *.so
 *.o
 *.a
+*.swp
 mkmf.log
+bummr-*.gem

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 *.swp
 mkmf.log
 bummr-*.gem
+.DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bummr (1.1.0)
+    bummr (1.1.1a)
       rainbow
       thor
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Update gemname from 0.0.1 to 0.0.2
 - Once the build passes, you can push your branch and create a pull-request!
 - You may wish to `tail -f log/bummr.log` in a separate terminal window so you
   can see which commits are being removed.
+- Environment variables that adjust bummr behavior
+  - BUMMR_TEST = your app's testing suite command (default: `bundle exec rake`)
+  - BASE_BRANCH = your repo's primary branch (default: `main`)
+  - BUMMR_HEADLESS = skip interactive rebase after all updates are complete (default: `false`)
+  - BUMMR_GIT_COMMIT = the shell git commit command to be used (default: `git commit`)
+
 
 ## License
 

--- a/bummr.gemspec
+++ b/bummr.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/lpender/bummr"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = Dir["{lib,bin}/**/*"] + %w|LICENSE README.md|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]

--- a/bummr.gemspec
+++ b/bummr.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  # Toolkit for building powerful command-line interfaces
   spec.add_dependency "thor"
+  # Colorize printed text on ANSI terminals
   spec.add_dependency "rainbow"
 
   spec.add_development_dependency "rspec"

--- a/lib/bummr/bisecter.rb
+++ b/lib/bummr/bisecter.rb
@@ -20,7 +20,7 @@ module Bummr
           end
 
           if line == "bisect run success\n"
-            Bummr::Remover.instance.remove_commit(sha)
+            puts Bummr::Remover.instance.remove_commit(sha)
           end
         end
       end

--- a/lib/bummr/check.rb
+++ b/lib/bummr/check.rb
@@ -27,7 +27,7 @@ module Bummr
     private
 
     def check_base_branch
-      if `git rev-parse --abbrev-ref HEAD` == "#{BASE_BRANCH}\n"
+      if %x{git rev-parse --abbrev-ref HEAD} == "#{BASE_BRANCH}\n"
         message = "Bummr is not meant to be run on your base branch"
         puts message.color(:red)
         puts "Please checkout a branch with 'git checkout -b update-gems'"
@@ -44,7 +44,7 @@ module Bummr
     end
 
     def check_status
-      status = `git status`
+      status = %x{git status}
 
       if status.index 'are currently'
         message = ""
@@ -55,15 +55,15 @@ module Bummr
           message += "You are already bisecting. "
         end
 
-        message += "Make sure `git status` is clean"
+        message += "Make sure 'git status' is clean"
         puts message.color(:red)
         @errors.push message
       end
     end
 
     def check_diff
-      unless `git diff #{BASE_BRANCH}`.empty?
-        message = "Please make sure that `git diff #{BASE_BRANCH}` returns empty"
+      unless %x{git diff #{BASE_BRANCH}}.empty?
+        message = "Please make sure that 'git diff #{BASE_BRANCH}' returns empty"
         puts message.color(:red)
         @errors.push message
       end

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -79,7 +79,7 @@ module Bummr
 
     desc "remove_commit", "Remove a commit from the history"
     def remove_commit(sha)
-      Bummr::Remover.instance.remove_commit(sha)
+      puts Bummr::Remover.instance.remove_commit(sha)
     end
 
     private

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -84,6 +84,7 @@ module Bummr
 
     private
 
+    # :nocov:
     def display_info
       puts "Bummr #{VERSION}"
       puts "To run Bummr, you must:"
@@ -108,5 +109,6 @@ module Bummr
 
       puts "\nRun '#{"bummr help update".color(:yellow)}' for more information.\n\n"
     end
+    # :nocov: end
   end
 end

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -92,7 +92,7 @@ module Bummr
       puts "- Have a 'log' directory, where we can place logs"
       puts "- Have your build configured to fail fast (recommended)"
       puts "- Have locked any Gem version that you don't wish to update in your Gemfile"
-      puts "- It is recommended that you lock your versions of `ruby` and `rails` in your `Gemfile`"
+      puts "- It is recommended that you lock your versions of 'ruby' and 'rails' in your 'Gemfile'"
       puts "\n"
       puts "Your test command is: " + "'#{TEST_COMMAND}'".color(:yellow)
       puts "\n"
@@ -106,7 +106,7 @@ module Bummr
         puts "--#{key.color(:yellow)}: #{value}"
       end
 
-      puts "\nRun `#{"bummr help update".color(:yellow)}` for more information.\n\n"
+      puts "\nRun '#{"bummr help update".color(:yellow)}' for more information.\n\n"
     end
   end
 end

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -8,10 +8,12 @@ module Bummr
     include Bummr::Prompt
     include Bummr::Scm
 
+    # :nocov: internals are tested by spec/check_spec.rb
     desc "check", "Run automated checks to see if bummr can be run"
     def check(fullcheck=true)
       Bummr::Check.instance.check(fullcheck)
     end
+    # :nocov: end
 
     desc "update",
       "Update outdated gems, run tests, bisect if tests fail\n\n" +
@@ -77,14 +79,16 @@ module Bummr
       end
     end
 
+    # :nocov: internals are tested by spec/lib/remover_spec.rb
     desc "remove_commit", "Remove a commit from the history"
     def remove_commit(sha)
       puts Bummr::Remover.instance.remove_commit(sha)
     end
+    # :nocov: end
 
     private
 
-    # :nocov:
+    # :nocov: This is stubbed out during actual testing because its boilerplate information for the user
     def display_info
       puts "Bummr #{VERSION}"
       puts "To run Bummr, you must:"

--- a/lib/bummr/git.rb
+++ b/lib/bummr/git.rb
@@ -20,6 +20,7 @@ module Bummr
       system("git rebase -i #{BASE_BRANCH}") unless HEADLESS
     end
 
+    # print only the commit subject line
     def message(sha)
       `git log --pretty=format:'%s' -n 1 #{sha}`
     end

--- a/lib/bummr/git.rb
+++ b/lib/bummr/git.rb
@@ -22,7 +22,7 @@ module Bummr
 
     # print only the commit subject line
     def message(sha)
-      `git log --pretty=format:'%s' -n 1 #{sha}`
+      %x{git log --pretty=format:'%s' -n 1 #{sha}}
     end
 
     private

--- a/lib/bummr/outdated.rb
+++ b/lib/bummr/outdated.rb
@@ -43,8 +43,11 @@ module Bummr
       /gem ['"]#{gem_name}['"]/.match gemfile
     end
 
+    # :nocov: no need to test whether linux "cat Gemfile" works
     def gemfile
       @gemfile ||= %x{cat Gemfile}
     end
+    # :nocov: end
+
   end
 end

--- a/lib/bummr/outdated.rb
+++ b/lib/bummr/outdated.rb
@@ -44,7 +44,7 @@ module Bummr
     end
 
     def gemfile
-      @gemfile ||= `cat Gemfile`
+      @gemfile ||= %x{cat Gemfile}
     end
   end
 end

--- a/lib/bummr/outdated.rb
+++ b/lib/bummr/outdated.rb
@@ -17,7 +17,7 @@ module Bummr
 
       Open3.popen2("bundle outdated" + bundle_options) do |_std_in, std_out|
         while line = std_out.gets
-          puts line
+          puts line # TODO: remove this if possible (pointless for spec tests)
           gem = parse_gem_from(line)
 
           if gem && (options[:all_gems] || gemfile_contains(gem[:name]))

--- a/lib/bummr/remover.rb
+++ b/lib/bummr/remover.rb
@@ -20,7 +20,7 @@ module Bummr
         "    - Commit the changes.\n" +
         "    - Run `bummr update` again.\n\n"
 
-      puts message.color(:yellow)
+      message.color(:yellow)
     end
   end
 end

--- a/lib/bummr/remover.rb
+++ b/lib/bummr/remover.rb
@@ -10,15 +10,15 @@ module Bummr
       log "Resetting..."
       system("git bisect reset")
 
-      message = "\nThe commit:\n\n `#{sha} #{git.message(sha)}`\n\n" +
+      message = "\nThe commit:\n\n '#{sha} #{git.message(sha)}'\n\n" +
         "Is breaking the build.\n\n" +
         "Please do one of the following: \n\n" +
         " 1. Update your code to work with the latest version of this gem.\n\n" +
         " 2. Perform the following steps to lock the gem version:\n\n" +
-        "    - `git reset --hard main`\n" +
+        "    - 'git reset --hard main'\n" +
         "    - Lock the version of this Gem in your Gemfile.\n" +
         "    - Commit the changes.\n" +
-        "    - Run `bummr update` again.\n\n"
+        "    - Run 'bummr update' again.\n\n"
 
       message.color(:yellow)
     end

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -43,7 +43,7 @@ module Bummr
     end
 
     def updated_version_for(gem)
-      string = `bundle list --paths | grep "#{gem[:name]}"`
+      string = %x{bundle list --paths | grep "#{gem[:name]}"}
       string.match(/#{gem[:name]}-(.*)$/)[1]
     end
   end

--- a/lib/bummr/version.rb
+++ b/lib/bummr/version.rb
@@ -1,3 +1,3 @@
 module Bummr
-  VERSION = "1.1.0"
+  VERSION = "1.1.1a"
 end

--- a/spec/black_box/bummr_update_spec.rb
+++ b/spec/black_box/bummr_update_spec.rb
@@ -2,6 +2,10 @@ require "spec_helper"
 require "jet_black"
 
 describe "bummr update command" do
+  before(:all) do
+    puts "\n<< black_box/bummr_update_spec >>\n"
+  end
+
   let(:session) { JetBlack::Session.new(options: { clean_bundler_env: true }) }
   let(:bummr_gem_path) { File.expand_path("../../", __dir__) }
 

--- a/spec/check_spec.rb
+++ b/spec/check_spec.rb
@@ -85,7 +85,7 @@ describe Bummr::Check do
           check.check
 
           expect(check).to have_received(:puts)
-            .with("You are already bisecting. Make sure `git status` is clean".color(:red))
+            .with("You are already bisecting. Make sure 'git status' is clean".color(:red))
           expect(check).to have_received(:yes?)
           expect(check).to have_received(:exit).with(0)
         end
@@ -102,7 +102,7 @@ describe Bummr::Check do
           check.check
 
           expect(check).to have_received(:puts)
-            .with("You are already rebasing. Make sure `git status` is clean".color(:red))
+            .with("You are already rebasing. Make sure 'git status' is clean".color(:red))
           expect(check).to have_received(:yes?)
           expect(check).to have_received(:exit).with(0)
         end
@@ -120,7 +120,7 @@ describe Bummr::Check do
         check.check(true)
 
         expect(check).to have_received(:puts)
-          .with("Please make sure that `git diff main` returns empty".color(:red))
+          .with("Please make sure that 'git diff main' returns empty".color(:red))
         expect(check).to have_received(:yes?)
         expect(check).to have_received(:exit).with(0)
       end

--- a/spec/check_spec.rb
+++ b/spec/check_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Bummr::Check do
+  before(:all) do
+    puts "\n<< Bummr::Check >>\n"
+  end
+
   let(:check) { Bummr::Check.instance }
 
   before(:each) do

--- a/spec/lib/bisecter_spec.rb
+++ b/spec/lib/bisecter_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Bummr::Bisecter do
+  before(:all) do
+    puts "\n<< Bummr::Bisecter >>\n"
+  end
+
   let(:std_out_err_bad_commit) {
     output = String.new
     output += "mybadcommit is the first bad commit\n"

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -22,6 +22,7 @@ describe Bummr::CLI do
   describe "#update" do
     context "when user rejects moving forward" do
       it "does not attempt to move forward" do
+        expect(cli).to receive(:display_info) # NOOP this function call
         expect(cli).to receive(:yes?).and_return(false)
         expect(cli).not_to receive(:check)
 

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Bummr::CLI do
+  before(:all) do
+    puts "\n<< Bummr::CLI >>\n"
+  end
+
   # https://github.com/wireframe/gitx/blob/171da367072b0e82d5906d1e5b3f8ff38e5774e7/spec/thegarage/gitx/cli/release_command_spec.rb#L9
   let(:args) { [] }
   let(:options) { {} }

--- a/spec/lib/git_spec.rb
+++ b/spec/lib/git_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 describe Bummr::Git do
+  before(:all) do
+    puts "\n<< Bummr::Git >>\n"
+  end
+
   describe "#add" do
     it "stages specified files with git" do
       git = stub_git

--- a/spec/lib/log_spec.rb
+++ b/spec/lib/log_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 describe Bummr::Log do
+  before(:all) do
+    puts "\n<< Bummr::Log >>\n"
+  end
+
   let(:object) { Object.new }
   let(:message) { "test message" }
 

--- a/spec/lib/log_spec.rb
+++ b/spec/lib/log_spec.rb
@@ -9,12 +9,12 @@ describe Bummr::Log do
   let(:message) { "test message" }
 
   before do
-    `mkdir -p log`
+    %x{mkdir -p log}
     object.extend(Bummr::Log)
   end
 
   after do
-    `rm log/bummr.log`
+    %x{rm log/bummr.log}
   end
 
   describe "#log" do
@@ -29,7 +29,7 @@ describe Bummr::Log do
     it "outputs the message to log/bummr.log" do
       object.log message
 
-      result = `cat log/bummr.log`
+      result = %x{cat log/bummr.log}
 
       expect(result).to eq message + "\n"
     end

--- a/spec/lib/log_spec.rb
+++ b/spec/lib/log_spec.rb
@@ -27,6 +27,8 @@ describe Bummr::Log do
     end
 
     it "outputs the message to log/bummr.log" do
+      allow(object).to receive(:puts) # NOOP this function call
+
       object.log message
 
       result = %x{cat log/bummr.log}

--- a/spec/lib/outdated_spec.rb
+++ b/spec/lib/outdated_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Bummr::Outdated do
+  before(:all) do
+    puts "\n<< Bummr::Outdated >>\n"
+  end
+
   # https://github.com/wireframe/gitx/blob/8e3cdc8b5d0c2082ed3daaf2fc054654b2e7a6c8/spec/gitx/executor_spec.rb#L9
   let(:stdoutput_legacy) {
     output = String.new

--- a/spec/lib/outdated_spec.rb
+++ b/spec/lib/outdated_spec.rb
@@ -31,10 +31,15 @@ describe Bummr::Outdated do
   }
 
   describe "#outdated_gems" do
+    def mock_gemfile
+      allow_any_instance_of(described_class).to receive(:gemfile).and_return gemfile
+      allow_any_instance_of(described_class).to receive(:puts) # NOOP this function call
+    end
+
     { bundler2: :stdoutput, bundler1: :stdoutput_legacy }.each_pair do |version, output|
       it "Correctly identifies outdated gems with bundler #{version}" do
         allow(Open3).to receive(:popen2).and_yield(nil, public_send(output))
-        allow_any_instance_of(described_class).to receive(:gemfile).and_return gemfile
+        mock_gemfile
 
         instance = Bummr::Outdated.instance
         result = instance.outdated_gems
@@ -61,7 +66,7 @@ describe Bummr::Outdated do
       it "lists all outdated dependencies by omitting the strict option" do
         allow(Open3).to receive(:popen2).with("bundle outdated --parseable").and_yield(nil, stdoutput)
 
-        allow(Bummr::Outdated.instance).to receive(:gemfile).and_return gemfile
+        mock_gemfile
 
         results = Bummr::Outdated.instance.outdated_gems(all_gems: true)
         gem_names = results.map { |result| result[:name] }
@@ -72,7 +77,7 @@ describe Bummr::Outdated do
       it "defaults to false" do
         expect(Open3).to receive(:popen2).with("bundle outdated --parseable --strict").and_yield(nil, stdoutput)
 
-        allow(Bummr::Outdated.instance).to receive(:gemfile).and_return gemfile
+        mock_gemfile
 
         results = Bummr::Outdated.instance.outdated_gems
         gem_names = results.map { |result| result[:name] }
@@ -93,7 +98,7 @@ describe Bummr::Outdated do
           .with("bundle outdated --parseable --strict --group development")
           .and_yield(nil, stdoutput_from_development_group)
 
-        allow(Bummr::Outdated.instance).to receive(:gemfile).and_return gemfile
+        mock_gemfile
 
         results = Bummr::Outdated.instance.outdated_gems(group: :development)
         gem_names = results.map { |result| result[:name] }
@@ -106,7 +111,7 @@ describe Bummr::Outdated do
           .with("bundle outdated --parseable --strict")
           .and_yield(nil, stdoutput)
 
-        allow(Bummr::Outdated.instance).to receive(:gemfile).and_return gemfile
+        mock_gemfile
 
         results = Bummr::Outdated.instance.outdated_gems
         gem_names = results.map { |result| result[:name] }
@@ -127,7 +132,7 @@ describe Bummr::Outdated do
           .with("bundle outdated --parseable --strict spring")
           .and_yield(nil, stdoutput_from_spring_gem)
 
-        allow(Bummr::Outdated.instance).to receive(:gemfile).and_return gemfile
+        mock_gemfile
 
         results = Bummr::Outdated.instance.outdated_gems(gem: :spring)
         gem_names = results.map { |result| result[:name] }
@@ -135,7 +140,7 @@ describe Bummr::Outdated do
         expect(gem_names).to match_array ['spring']
       end
     end
-  end
+  end # end #outdated_gems
 
   describe "#parse_gem_from" do
     it 'line' do

--- a/spec/lib/outdated_spec.rb
+++ b/spec/lib/outdated_spec.rb
@@ -32,8 +32,8 @@ describe Bummr::Outdated do
 
   describe "#outdated_gems" do
     { bundler2: :stdoutput, bundler1: :stdoutput_legacy }.each_pair do |version, output|
-    it "Correctly identifies outdated gems with bundler #{version}" do
-      allow(Open3).to receive(:popen2).and_yield(nil, public_send(output))
+      it "Correctly identifies outdated gems with bundler #{version}" do
+        allow(Open3).to receive(:popen2).and_yield(nil, public_send(output))
         allow_any_instance_of(described_class).to receive(:gemfile).and_return gemfile
 
         instance = Bummr::Outdated.instance

--- a/spec/lib/prompt_spec.rb
+++ b/spec/lib/prompt_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 describe Bummr::Prompt do
+  before(:all) do
+    puts "\n<< Bummr::Prompt >>\n"
+  end
+
   let(:parent_class) do
     Class.new do
       def yes?(message)

--- a/spec/lib/remover_spec.rb
+++ b/spec/lib/remover_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Bummr::Remover do
   let(:remover) { Bummr::Remover.instance }
   let(:git) { Bummr::Git.instance }
-  let(:sha) { "testsha" }
+  let(:sha) { "HEAD~1" }
 
   before do
     allow(remover).to receive(:log)

--- a/spec/lib/remover_spec.rb
+++ b/spec/lib/remover_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 describe Bummr::Remover do
+  before(:all) do
+    puts "\n<< Bummr::Remover >>\n"
+  end
+
   let(:remover) { Bummr::Remover.instance }
   let(:git) { Bummr::Git.instance }
   let(:sha) { "HEAD~1" }

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 describe Bummr::Updater do
+  before(:all) do
+    puts "\n<< Bummr::Updater >>\n"
+  end
+
   let(:outdated_gems) {
     [
       { name: "myGem", installed: "0.3.2", newest: "0.3.5" },

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -34,6 +34,14 @@ describe Bummr::Updater do
   end
 
   describe "#update_gem" do
+    # Ensure this directory exists to be added
+    before do
+      %x{mkdir -p vendor/cache}
+    end
+    after do
+      %x{rm -rf vendor/cache}
+    end
+
     def mock_log_commit_puts
       allow(updater).to receive(:log)
       allow(updater).to receive(:puts) # NOOP this function call
@@ -91,6 +99,7 @@ describe Bummr::Updater do
       it "commits" do
         commit_message =
           "Update #{gem[:name]} from #{gem[:installed]} to #{intermediate_version}"
+
         allow(updater).to receive(:system)
         allow(git).to receive(:add)
         mock_log_commit_puts
@@ -112,6 +121,7 @@ describe Bummr::Updater do
       it "commits" do
         commit_message =
           "Update #{gem[:name]} from #{gem[:installed]} to #{gem[:newest]}"
+
         allow(updater).to receive(:system)
         allow(git).to receive(:add)
         mock_log_commit_puts

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -23,6 +23,7 @@ describe Bummr::Updater do
   describe "#update_gems" do
     it "calls update_gem on each gem" do
       allow(updater).to receive(:update_gem)
+      allow(updater).to receive(:puts) # NOOP this function call
 
       updater.update_gems
 
@@ -33,11 +34,16 @@ describe Bummr::Updater do
   end
 
   describe "#update_gem" do
+    def mock_log_commit_puts
+      allow(updater).to receive(:log)
+      allow(updater).to receive(:puts) # NOOP this function call
+      allow(git).to receive(:commit)
+    end
+
     it "attempts to update the gem" do
       allow(updater).to receive(:system).with(update_cmd)
       allow(updater).to receive(:updated_version_for).with(gem).and_return installed
-      allow(updater).to receive(:log)
-      allow(git).to receive(:commit)
+      mock_log_commit_puts
 
       updater.update_gem(gem, 0)
     end
@@ -46,8 +52,7 @@ describe Bummr::Updater do
       it "logs that it's not updated to the latest" do
         allow(updater).to receive(:system).with(update_cmd)
         allow(updater).to receive(:updated_version_for).with(gem).and_return installed
-        allow(updater).to receive(:log)
-        allow(git).to receive(:commit)
+        mock_log_commit_puts
 
         updater.update_gem(gem, 0)
 
@@ -57,8 +62,7 @@ describe Bummr::Updater do
       it "doesn't commit anything" do
         allow(updater).to receive(:system).with(update_cmd)
         allow(updater).to receive(:updated_version_for).with(gem).and_return installed
-        allow(updater).to receive(:log)
-        allow(git).to receive(:commit)
+        mock_log_commit_puts
 
         updater.update_gem(gem, 0)
 
@@ -77,8 +81,7 @@ describe Bummr::Updater do
         not_latest_message =
           "#{gem[:name]} not updated from #{gem[:installed]} to latest: #{gem[:newest]}"
         allow(updater).to receive(:system)
-        allow(updater).to receive(:log)
-        allow(git).to receive(:commit)
+        mock_log_commit_puts
 
         updater.update_gem(gem, 0)
 
@@ -89,9 +92,8 @@ describe Bummr::Updater do
         commit_message =
           "Update #{gem[:name]} from #{gem[:installed]} to #{intermediate_version}"
         allow(updater).to receive(:system)
-        allow(updater).to receive(:log)
         allow(git).to receive(:add)
-        allow(git).to receive(:commit)
+        mock_log_commit_puts
 
         updater.update_gem(gem, 0)
 
@@ -111,9 +113,8 @@ describe Bummr::Updater do
         commit_message =
           "Update #{gem[:name]} from #{gem[:installed]} to #{gem[:newest]}"
         allow(updater).to receive(:system)
-        allow(updater).to receive(:log)
         allow(git).to receive(:add)
-        allow(git).to receive(:commit)
+        mock_log_commit_puts
 
         updater.update_gem(gem, 0)
 
@@ -123,7 +124,7 @@ describe Bummr::Updater do
         expect(git).to have_received(:commit).with(commit_message)
       end
     end
-  end
+  end # end #update_gem
 
   describe "#updated_version_for" do
     it "returns the correct version from bundle list" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
 require "simplecov"
-SimpleCov.start
+SimpleCov.start do
+  # Exclude spec files from coverage
+  add_filter '/spec/'
+
+  git_branch_name = %x{git rev-parse --abbrev-ref HEAD}.strip
+  SimpleCov.coverage_dir("coverage/#{git_branch_name}")
+end
 
 require 'pry'
 require 'bummr'


### PR DESCRIPTION
Included changes:
- update `gitignore` to exclude more files/folders
- slim down the gemspec.files built into the gem, remove un-necessary stuff
- Updated readme to document all the current environment flags that are recognized
- Cleaned up a lot of noise within the spec tests themselves
  - Fixed `fatal: ambiguous argument 'testsha': unknown revision or path not in the working tree.`
  - Fixed `fatal: pathspec 'vendor/cache' did not match any files` by ensuring `vendor/cache` exists
  - Removed printouts from `Bummr::Remover.instance.remove_commit` testing
  - Silenced "display_info" when testing ABORTING bummr update
  - Silenced "puts" when testing
    - outdated_gems
    - writing to log/bummr.log
    - updater
- Added a printout during spec tests separating which test file is currently running
- Converted shell execution backticks to `%x{}` instead
- Converted quoted backticks to `'` instead
- Excluded several sections from coverage testing
  - `cli#display_info` - this is just informational for the users. Its always printed.
  - `cli#check` - redundant with spec/check_spec.rb
  - `cli#remove_commit` - redundant with spec/lib/remover_spec.rb
  - `outdated#gemfile` - no need to test whether linux "cat Gemfile" works
- Tweaked coverage report
   - Write the report into `/coverage/<branch_name>`
   - Exclude all spec files from coverage